### PR TITLE
ocultar boton de listas

### DIFF
--- a/src/pages/ballot/index.tsx
+++ b/src/pages/ballot/index.tsx
@@ -277,10 +277,6 @@ const EmptyBallot = () => (
         <Button as={Link} href={"/projects"}>
           View projects
         </Button>
-        <div className="text-gray-700">or</div>
-        <Button as={Link} href={"/lists"}>
-          View lists
-        </Button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Ocultar botón que hace referencia a listas
[P5 - Desactivar la gestión de listas](https://www.notion.so/launamu/P5-Desactivar-la-gesti-n-de-listas-09c6cd7cbf8d42fe9ffe4200452fafb5?pvs=4)