### PR TITLE
fix: remove unused hook update

### DIFF
--- a/src/features/ballot/components/AllocationList.tsx
+++ b/src/features/ballot/components/AllocationList.tsx
@@ -68,16 +68,14 @@ export function AllocationFormWrapper({
   renderExtraColumn,
 }: AllocationFormProps) {
   const form = useFormContext<{ votes: Vote[] }>();
-  const { initialVoiceCredits, pollId } = useMaci();
-  const { ballot, sumBallot, addToBallot: onSave, removeFromBallot: onRemove } = useBallot();
+  const { pollId } = useMaci();
+  const { addToBallot: onSave, removeFromBallot: onRemove } = useBallot();
 
   const { fields, remove } = useFieldArray({
     name: "votes",
     keyName: "key",
     control: form.control,
   });
-
-  const sum = sumBallot(ballot?.votes ?? []);
 
   const handleOnBlur = useCallback(() => {
     onSave(form.getValues().votes, pollId!);
@@ -105,7 +103,6 @@ export function AllocationFormWrapper({
                     name={`votes.${idx}.amount`}
                     disabled={disabled}
                     defaultValue={project.amount}
-                    votingMaxProject={Math.sqrt(Math.min(initialVoiceCredits, initialVoiceCredits - sum))}
                     onBlur={handleOnBlur}
                   />
                 </Td>

--- a/src/pages/ballot/index.tsx
+++ b/src/pages/ballot/index.tsx
@@ -27,12 +27,7 @@ export default function BallotPage() {
     }
   }, [address, isConnecting, router]);
 
-  const votes = useMemo(
-    () => ballot?.votes?.sort((a, b) => b.amount - a.amount),
-    [ballot],
-  );
-
-  if (!votes) {
+  if (!ballot) {
     return <EmptyBallot />;
   }
 


### PR DESCRIPTION
**Description**
Once the ballot is set again, the `useMemo` hook update, which causes the form wanna sort the votes, but actually is just changing the projects order. The sorting is actually unused, so removed.